### PR TITLE
Update `package.py` URLs for split repo

### DIFF
--- a/package.html
+++ b/package.html
@@ -72,7 +72,7 @@
         if (/^[0-9]/.test(name) || _reserved_names.has(name)) {
           name = `_${name}`;
         }
-        return `https://github.com/spack/spack/tree/develop/var/spack/repos/spack_repo/builtin/packages/${name}/package.py`;
+        return `https://github.com/spack/spack-packages/tree/develop/repos/spack_repo/builtin/packages/${name}/package.py`;
       },
 
       maintainerUrl(maintainer) {


### PR DESCRIPTION
Since https://github.com/spack/spack/pull/50804, Spack's `builtin` repository is in its own github repo at https://github.com/spack/spack-packages.

- [x] Update package URLs on `packages.spack.io` to point to the new repo