### PR TITLE
Make search case-insensitive

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       query: '',
       packages: [],
       more_results: false,
+      case_sensitive: true,
 
       init() {
         this.loadPackages();
@@ -49,7 +50,8 @@
         }
 
         try {
-          const regex = RegExp(this.query);
+          if (this.case_sensitive) flags = ""; else flags = "i";
+          const regex = RegExp(this.query, flags);
           const results = this.packages.filter(pkg => {
             return regex.test(pkg.name);
           })
@@ -112,7 +114,11 @@
       <!-- Search Box -->
       <div class="bg-primary border-l-4 border-secondary flex flex-col gap-8 p-8 rounded">
         <div class="form-control">
-          <input type="text" id="search-box" placeholder="Search" autofocus class="input input-bordered input-lg w-full" x-model="query">
+          <input type="text" id="search-box" placeholder="Search" autofocus autocapitalize="off" class="input input-bordered input-lg w-full" x-model="query">
+      </div>
+        <div id="search-options" class="text-gray-300">
+          <input type="checkbox" id="case_sensitive" x-model="case_sensitive">
+          <label for="case_sensitive">Case Sensitive</label>
         </div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@
       query: '',
       packages: [],
       more_results: false,
-      case_sensitive: true,
 
       init() {
         this.loadPackages();
@@ -50,8 +49,7 @@
         }
 
         try {
-          if (this.case_sensitive) flags = ""; else flags = "i";
-          const regex = RegExp(this.query, flags);
+          const regex = RegExp(this.query, "i");
           const results = this.packages.filter(pkg => {
             return regex.test(pkg.name);
           })
@@ -115,10 +113,6 @@
       <div class="bg-primary border-l-4 border-secondary flex flex-col gap-8 p-8 rounded">
         <div class="form-control">
           <input type="text" id="search-box" placeholder="Search" autofocus autocapitalize="off" class="input input-bordered input-lg w-full" x-model="query">
-      </div>
-        <div id="search-options" class="text-gray-300">
-          <input type="checkbox" id="case_sensitive" x-model="case_sensitive">
-          <label for="case_sensitive">Case Sensitive</label>
         </div>
       </div>
 


### PR DESCRIPTION
This MR provides two changes:

1. It sets `autocapitalize="off"` on the search input, so mobile browsers default to lower case when searching.
2. It provides a checkbox for doing case sensitive search, which is off by default.

<img width="975" height="696" alt="Screenshot 2025-07-13 at 9 51 06 AM" src="https://github.com/user-attachments/assets/9f3927c7-1914-4334-94d5-f277884d88c7" />
