### PR TITLE
fix: extraction script `spack.repo` failures

### DIFF
--- a/generate_packages.py
+++ b/generate_packages.py
@@ -36,7 +36,7 @@ def write_json(content, filename):
 
 def main():
 
-    pkgs = spack.repo.all_package_names(include_virtuals=True)
+    pkgs = spack.repo.PATH.all_package_names(include_virtuals=True)
     deps_of = {}
     descriptions = {}
     metas = {}


### PR DESCRIPTION
the extraction job was failing with: https://github.com/spack/packages.spack.io/actions/runs/29983698324/job/89130851595

https://github.com/spack/spack/pull/52759/changes removed the `repo.all_package_names` helper

closes #47 