### PR TITLE
fix: clone spack to specific commit

### DIFF
--- a/.github/workflows/update-ui.yaml
+++ b/.github/workflows/update-ui.yaml
@@ -13,7 +13,9 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Clone development branch of spack
-      run: git clone https://github.com/spack/spack /opt/spack
+      run: |
+        git clone https://github.com/spack/spack /opt/spack
+        git -C /opt/spack reset --hard e2c5745352ebc0465ebc8d548e60759f05173c83  # Jul 28, 2026
     - name: Run update script
       run: |
          export PATH=/opt/spack/bin:$PATH


### PR DESCRIPTION
This PR modifies the update script to use a specific commit to avoid unintended breakage through changes in core. We can't write outside GITHUB_WORKSPACE with regulars like actions/checkout, so this remains a run step. We don't have weekly tags on spack/spack anymore, so this is a commit hash with date as comment.